### PR TITLE
v0.4.1 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 !examples/**/gui_definition.json
 !tests/**/*.json
 !CMakePresets.json
+!scr_schema.json
 
 *.txt
 !changelog.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,17 +48,21 @@ message(VERBOSE "CXX_FLAGS               : ${CMAKE_CXX_FLAGS}")
 message(VERBOSE "CXX_FLAGS_RELEASE       : ${CMAKE_CXX_FLAGS_RELEASE}")
 message(VERBOSE "EXE_LINKER_FLAGS        : ${CMAKE_EXE_LINKER_FLAGS}")
 message(VERBOSE "EXE_LINKER_FLAGS_RELEASE: ${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+message(VERBOSE "BUILD_TESTS             : ${BUILD_TESTS}")
+message(VERBOSE "BUILD_EXE               : ${BUILD_EXE}")
+message(VERBOSE "USE_JSON_EMBEDDING      : ${USE_JSON_EMBEDDING}")
 
 # find wxWidgets
 # set(CMAKE_FIND_DEBUG_MODE TRUE)
 find_package(wxWidgets REQUIRED COMPONENTS core base)
 include(${wxWidgets_USE_FILE})
 
-
 # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP:
 cmake_policy(SET CMP0135 NEW)
 
 # fetch json
+set(JSON_ImplicitConversions OFF)
+set(JSON_DisableEnumSerialization ON)
 include(FetchContent)
 FetchContent_Declare(
 	json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,18 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 	if (USE_JSON_EMBEDDING)
 		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} /DUSE_JSON_EMBEDDING=1")
 	endif()
+else()
+    message(WARNING "${PROJECT_NAME} does NOT support your compiler. You might get some problems.")
 endif()
 
+# check OS
+if (NOT ((${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+		OR (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+		OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux")))
+	message(WARNING "${PROJECT_NAME} does NOT support your OS. You might get some problems.")
+endif()
+
+# Show settings
 message(VERBOSE "SYSTEM                  : ${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_VERSION}")
 message(VERBOSE "COMPILER                : ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
 message(VERBOSE "CXX_FLAGS               : ${CMAKE_CXX_FLAGS}")

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,6 @@
 ver 0.4.1
+- Raise errors when the command requires more components or there are unused components.
+- Fixed a bug that "%%" won't escsape the "%" symbol.
 - Fixed a bug that the window is resizable on macOS and Linux.
 - Refined codes.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 ver 0.4.1
-- Fixed a bug that the window is resizable on macOS and Linux
+- Fixed a bug that the window is resizable on macOS and Linux.
+- Refined codes.
 
 ver 0.4.0
 - Changed license to GPL

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 ver 0.4.1
 - Raise errors when the command requires more components or there are unused components.
+- Error messages bacame more detailed when failed to parse commands.
+- Commands will be shown in the log when loading definitions.
 - Fixed a bug that "%%" won't escsape the "%" symbol.
 - Fixed a bug that the window is resizable on macOS and Linux.
 - Fixed typos.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+ver 0.4.1
+- Fixed a bug that the window is resizable on macOS and Linux
+
 ver 0.4.0
 - Changed license to GPL
 - Added options for exit code.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ ver 0.4.1
 - Raise errors when the command requires more components or there are unused components.
 - Fixed a bug that "%%" won't escsape the "%" symbol.
 - Fixed a bug that the window is resizable on macOS and Linux.
+- Fixed typos.
 - Refined codes.
 
 ver 0.4.0

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,8 +1,22 @@
 # Frequently Asked Questions
 
-## Can I distribute the exe with my scripts?
+## Can I redistribute the exe with my scripts?
 
 Yes, and you can rename it to `GUI.exe`, `'project name'-GUI.exe`, or `'project name'_GUI.exe`.  
+But note that it's licensed under GPL.  
+You should inform users of the license and the link to the source code.  
+
+## How can I insert an input into multiple places in commands?
+
+Use the [`id`](../examples/comp_options/id/) option for components.  
+You can use the defined IDs as variable names in commands.  
+
+## How can I run multiple commands at the same time?
+
+Simple Command Runner will execute a single line command on the command prompt (or the terminal.)  
+So, it's the same question as "How can I run multiple commands as a single line on the command prompt (or the terminal?)"  
+It's a little complicated task, but you can find tons of websites that explain about it.  
+Also, you can see [some examples](../examples/tips/multi_lines/) about it.
 
 ## What's `gui_config.json` for?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Simple-Command-Runner ver 0.4.0
+# Simple Command Runner ver 0.4.0
 
 ![build](https://github.com/matyalatte/Simple-Command-Runner/actions/workflows/build_all.yml/badge.svg)
 ![test](https://github.com/matyalatte/Simple-Command-Runner/actions/workflows/test.yml/badge.svg)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Simple Command Runner ver 0.4.0
+# Simple Command Runner ver 0.4.1
 
 ![build](https://github.com/matyalatte/Simple-Command-Runner/actions/workflows/build_all.yml/badge.svg)
 ![test](https://github.com/matyalatte/Simple-Command-Runner/actions/workflows/test.yml/badge.svg)

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ Examples for GUI components (e.g. file pickers)
 
 Examples for component options.
 
--   [IDs](./comp_options/id/): An option to set ids. You can use the defined ids in commands.
+-   [IDs](./comp_options/id/): An option to set ids. You can use them as variable names in commands.
 -   [Default Values](./comp_options/default/):  An option to set default values of components.
 -   [Tooltip](./comp_options/tooltip/): An option to show a message when the mouse cursor is on a component.
 
@@ -44,3 +44,9 @@ There are more features you can use.
 ## 5. All Keys
 
 [The json file that has all supported keys.](./all_keys/)  
+
+## 6. Tips
+
+Not about the features of the tool, but they might help you.
+
+-   [Multiple Lines](./tips/multi_lines): How to run multiple commands in a process.

--- a/examples/comp_options/id/README.md
+++ b/examples/comp_options/id/README.md
@@ -25,7 +25,7 @@ You can use the defined ids as variable names in commands.
 
 ## Undefined IDs
 
-When you put an undefined id in `%*%`, it'll use one of the compoents that have no id.
+When you put an undefined id in `%*%`, it'll use one of the components that have no id.
 
 ```json
 {

--- a/examples/components/path_pickers/README.md
+++ b/examples/components/path_pickers/README.md
@@ -44,6 +44,7 @@ Each component should be defined as a dictionary.
 
 ## "command"
 
-Inputs of components will be injected into `command` when executing the command.<br>
-You can specifiy where you inject the inputs with `%*%`.<br>
-In the example, file path will be injected in `%foo%`, and folder path will be in `%bar%`.
+Inputs of components will be injected into `command` when executing the command.  
+You can specify where you inject the inputs with `%*%`.  
+In the example, the file path will be injected in `%foo%`, and the folder path will be in `%bar%`.  
+You can also use [`id`](../../comp_options/id) option to insert an input into multiple places.

--- a/examples/tips/multi_lines/README.md
+++ b/examples/tips/multi_lines/README.md
@@ -1,0 +1,43 @@
+# Multiple Lines
+
+Simple Command Runner will execute a single line command on the command prompt (or the terminal.)  
+If you want to executle multiple commands, you should merge them into a single line command.  
+I won't explain the details because it's the thing about the command-line, not the Simple Command Runner.  
+But you can see some examples about it.  
+
+## Windows
+
+For windows, you can join the commands with ` && `.  
+And some commands (e.g. for loop) require `()`.
+
+```json
+{
+    "label": "Search json in a folder (Windows)",
+    "command": "@echo off && (for %%f in (\"%dir%\\*.json\") do (echo %%f)) && echo Done!",
+    "button": "Echo!",
+    "components": [
+        {
+            "type": "folder",
+            "label": "a folder"
+        }
+    ]
+}
+```
+
+## Unix/Linux
+
+For non-Windows platforms, you can join the commands with `;`.
+
+```json
+{
+    "label": "Search json in a folder (Unix/Linux)",
+    "command": "for f in %dir%/*.json; do echo \"${f}\"; done; echo Done!",
+    "button": "Echo!",
+    "components": [
+        {
+            "type": "folder",
+            "label": "a folder"
+        }
+    ]
+}
+```

--- a/examples/tips/multi_lines/gui_definition.json
+++ b/examples/tips/multi_lines/gui_definition.json
@@ -1,0 +1,24 @@
+{
+    "gui": [
+        {
+            "label": "Search json in a folder (Windows)",
+            "command": "@echo off && (for %%f in (\"%dir%\\*.json\") do (echo %%f)) && echo Done!",
+            "components": [
+                {
+                    "type": "folder",
+                    "label": "a folder"
+                }
+            ]
+        },
+        {
+            "label": "Search json in a folder (Unix/Linux)",
+            "command": "for f in %dir%/*.json; do echo \"${f}\"; done; echo Done!",
+            "components": [
+                {
+                    "type": "folder",
+                    "label": "a folder"
+                }
+            ]
+        }
+    ]
+}

--- a/include/component.h
+++ b/include/component.h
@@ -6,7 +6,6 @@
 #include "wx/filepicker.h"
 #include "wx/dnd.h"
 #include "wx/spinctrl.h"
-#include "json_utils.h"
 #include "custom_wx_obj.h"
 
 // Base class for GUI components (file picker, combo box, etc.)

--- a/include/component.h
+++ b/include/component.h
@@ -8,6 +8,20 @@
 #include "wx/spinctrl.h"
 #include "custom_wx_obj.h"
 
+enum ComponentType: int {
+    COMP_UNKNOWN = 0,
+    COMP_STATIC_TEXT,
+    COMP_FILE,
+    COMP_FOLDER,
+    COMP_CHOICE,
+    COMP_CHECK,
+    COMP_CHECK_ARRAY,
+    COMP_TEXT,
+    COMP_INT,
+    COMP_FLOAT,
+    COMP_MAX
+};
+
 // Base class for GUI components (file picker, combo box, etc.)
 class Component {
  protected:

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -4,8 +4,23 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <map>
 #include <nlohmann/json.hpp>
 #include "scr_constants.h"
+
+enum ComponentType: int {
+    COMP_UNKNOWN = 0,
+    COMP_STATIC_TEXT,
+    COMP_FILE,
+    COMP_FOLDER,
+    COMP_CHOICE,
+    COMP_CHECK,
+    COMP_CHECK_ARRAY,
+    COMP_TEXT,
+    COMP_INT,
+    COMP_FLOAT,
+    COMP_MAX
+};
 
 namespace json_utils {
     nlohmann::json LoadJson(const std::string& file);

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -6,21 +6,16 @@
 #include <string>
 #include <nlohmann/json.hpp>
 #include "scr_constants.h"
+#include "component.h"
 #include "map_as_vec.hpp"
 
-enum ComponentType: int {
-    COMP_UNKNOWN = 0,
-    COMP_STATIC_TEXT,
-    COMP_FILE,
-    COMP_FOLDER,
-    COMP_CHOICE,
-    COMP_CHECK,
-    COMP_CHECK_ARRAY,
-    COMP_TEXT,
-    COMP_INT,
-    COMP_FLOAT,
-    COMP_MAX
+enum CmdPredefinedIds: int {
+    CMD_ID_PERCENT = -1,
+    CMD_ID_CURRENT_DIR = -2
 };
+
+constexpr char CMD_TOKEN_PERCENT[] = "";
+constexpr char CMD_TOKEN_CURRENT_DIR[] = "__CWD__";
 
 namespace json_utils {
     nlohmann::json LoadJson(const std::string& file);

--- a/include/json_utils.h
+++ b/include/json_utils.h
@@ -4,9 +4,9 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <map>
 #include <nlohmann/json.hpp>
 #include "scr_constants.h"
+#include "map_as_vec.hpp"
 
 enum ComponentType: int {
     COMP_UNKNOWN = 0,

--- a/include/map_as_vec.hpp
+++ b/include/map_as_vec.hpp
@@ -1,94 +1,94 @@
-#ifndef INCLUDE_MATYA_MAP_AS_VEC_HPP_
-#define INCLUDE_MATYA_MAP_AS_VEC_HPP_
+#ifndef INCLUDE_MAP_AS_VEC_HPP_
+#define INCLUDE_MAP_AS_VEC_HPP_
 
 #include <vector>
 #include <string>
 
 namespace matya {
 
-    // like a std::map but a vector of pairs.
-    // it's only for const char* -> T conversion.
-    // not fast for searching but small code.
-    template<typename T>
-    struct pair {
-        const char* key;
-        T value;
-    };
+// like a std::map but a vector of pairs.
+// it's only for const char* -> T conversion.
+// not fast for searching but small code.
+template<typename T>
+struct mav_pair {
+    const char* key;
+    T value;
+};
 
-    template<typename T>
-    class map_as_vec {
+template<typename T>
+class map_as_vec {
+ private:
+    typedef mav_pair<T> ItemT;
+    std::vector<ItemT> items;
 
-     private:
-        typedef typename pair<T> ItemT;
-        std::vector<ItemT> items;
+ public:
+    map_as_vec(): items() {}
 
-     public:
-        map_as_vec(): items() {}
+    // keys can be duplicated.
+    explicit map_as_vec(const std::vector<ItemT>& c_items): items(c_items) {}
+    map_as_vec(const std::initializer_list<ItemT>& c_items):
+        items(c_items.begin(), c_items.end()) {}
 
-        // keys can be duplicated.
-        map_as_vec(const std::vector<ItemT>& c_items): items(c_items) {}
-        map_as_vec(const std::initializer_list<ItemT>& c_items): items(c_items.begin(), c_items.end()) {}
+    T& operator[](const char* k) {
+        for (ItemT& i : items)
+            if ( strcmp(i.key, k) == 0 ) return i.value;
+        push_back(k, T());
+        return items.back().value;
+    }
 
-        T& operator[](const char* k) {
-            for (ItemT& i: items)
-                if ( strcmp(i.key, k) == 0 ) return i.value;
-            push_back(k, T());
-            return items.back().value;
-        }
+    // a key can be duplicated.
+    void push_back(const char* k, const T& v) { items.push_back({k, v}); }
 
-        // a key can be duplicated.
-        void push_back(const char* k, const T& v) { items.push_back({k, v}); }
+    const T& get(const char* k) const {
+        for (const ItemT& i : items)
+            if ( strcmp(i.key, k) == 0 ) return i.value;
+        throw std::runtime_error("Undefined key detected.");
+    }
 
-        const T& get(const char* k) const {
-            for (const ItemT& i: items)
-                if ( strcmp(i.key, k) == 0 ) return i.value;
-            throw std::runtime_error("Undefined key detected.");
-        }
+    const T& get(const std::string& k) const {
+        return get(k.c_str());
+    }
 
-        const T& get(const std::string& k) const {
-            return get(k.c_str());
-        }
+    const T& get(const char* k, const T& def_val) const {
+        for (const ItemT& i : items)
+            if ( strcmp(i.key, k) == 0 ) return i.value;
+        return def_val;
+    }
 
-        const T& get(const char* k, const T& def_val) const {
-            for (const ItemT& i: items)
-                if ( strcmp(i.key, k) == 0 ) return i.value;
-            return def_val;
-        }
+    const T& get(const std::string& k, const T& def_val) const {
+        return get(k.c_str(), def_val);
+    }
 
-        const T& get(const std::string& k, const T& def_val) const {
-            return get(k.c_str(), def_val);
-        }
+    bool has_key(const char* k) {
+        for (const ItemT& i : items)
+            if ( strcmp(i.key, k) == 0 ) return false;
+        return true;
+    }
 
-        bool has_key(const char* k) {
-            for (const ItemT& i: items)
-                if ( strcmp(i.key, k) == 0 ) return false;
-            return true;
-        }
+    size_t size() const { return items.size(); }
+    bool empty() const { return items.empty(); }
+    void clear() { items.clear(); }
 
-        size_t size() const { return items.size(); }
-        bool empty() const { return items.empty(); }
-        void clear() { items.clear(); }
+    typedef typename std::vector<ItemT>::iterator iterator;
+    typedef typename std::vector<ItemT>::const_iterator const_iterator;
+    typedef typename std::vector<ItemT>::reverse_iterator reverse_iterator;
+    typedef typename std::vector<ItemT>::const_reverse_iterator const_reverse_iterator;
 
-        typedef typename std::vector<ItemT>::iterator iterator;
-        typedef typename std::vector<ItemT>::const_iterator const_iterator;
-        typedef typename std::vector<ItemT>::reverse_iterator reverse_iterator;
-        typedef typename std::vector<ItemT>::const_reverse_iterator const_reverse_iterator;
+    iterator erase(const char* k) {
+        for (iterator& i : items)
+            if (strcmp(i.key, k) == 0) return items.erase(i);
+        return items.end();
+    }
 
-        iterator erase(const char* k) {
-            for(iterator& i; items)
-                if (strcmp(i.key, k) == 0) return items.erase(i);
-            return items.end();
-        }
-
-        // iterators
-        iterator begin(){ return items.begin(); }
-        const_iterator begin() const { return items.begin(); }
-        iterator end(){ return items.end(); }
-        const_iterator end() const { return items.end(); }
-        reverse_iterator rbegin() { return reverse_iterator(end()); }
-        const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
-        reverse_iterator rend() { return reverse_iterator(begin()); }
-        const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
-    };
-}
-#endif  // INCLUDE_MATYA_MAP_AS_VEC_HPP_
+    // iterators
+    iterator begin() { return items.begin(); }
+    const_iterator begin() const { return items.begin(); }
+    iterator end() { return items.end(); }
+    const_iterator end() const { return items.end(); }
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+};
+}  // namespace matya
+#endif  // INCLUDE_MAP_AS_VEC_HPP_

--- a/include/map_as_vec.hpp
+++ b/include/map_as_vec.hpp
@@ -1,0 +1,94 @@
+#ifndef INCLUDE_MATYA_MAP_AS_VEC_HPP_
+#define INCLUDE_MATYA_MAP_AS_VEC_HPP_
+
+#include <vector>
+#include <string>
+
+namespace matya {
+
+    // like a std::map but a vector of pairs.
+    // it's only for const char* -> T conversion.
+    // not fast for searching but small code.
+    template<typename T>
+    struct pair {
+        const char* key;
+        T value;
+    };
+
+    template<typename T>
+    class map_as_vec {
+
+     private:
+        typedef typename pair<T> ItemT;
+        std::vector<ItemT> items;
+
+     public:
+        map_as_vec(): items() {}
+
+        // keys can be duplicated.
+        map_as_vec(const std::vector<ItemT>& c_items): items(c_items) {}
+        map_as_vec(const std::initializer_list<ItemT>& c_items): items(c_items.begin(), c_items.end()) {}
+
+        T& operator[](const char* k) {
+            for (ItemT& i: items)
+                if ( strcmp(i.key, k) == 0 ) return i.value;
+            push_back(k, T());
+            return items.back().value;
+        }
+
+        // a key can be duplicated.
+        void push_back(const char* k, const T& v) { items.push_back({k, v}); }
+
+        const T& get(const char* k) const {
+            for (const ItemT& i: items)
+                if ( strcmp(i.key, k) == 0 ) return i.value;
+            throw std::runtime_error("Undefined key detected.");
+        }
+
+        const T& get(const std::string& k) const {
+            return get(k.c_str());
+        }
+
+        const T& get(const char* k, const T& def_val) const {
+            for (const ItemT& i: items)
+                if ( strcmp(i.key, k) == 0 ) return i.value;
+            return def_val;
+        }
+
+        const T& get(const std::string& k, const T& def_val) const {
+            return get(k.c_str(), def_val);
+        }
+
+        bool has_key(const char* k) {
+            for (const ItemT& i: items)
+                if ( strcmp(i.key, k) == 0 ) return false;
+            return true;
+        }
+
+        size_t size() const { return items.size(); }
+        bool empty() const { return items.empty(); }
+        void clear() { items.clear(); }
+
+        typedef typename std::vector<ItemT>::iterator iterator;
+        typedef typename std::vector<ItemT>::const_iterator const_iterator;
+        typedef typename std::vector<ItemT>::reverse_iterator reverse_iterator;
+        typedef typename std::vector<ItemT>::const_reverse_iterator const_reverse_iterator;
+
+        iterator erase(const char* k) {
+            for(iterator& i; items)
+                if (strcmp(i.key, k) == 0) return items.erase(i);
+            return items.end();
+        }
+
+        // iterators
+        iterator begin(){ return items.begin(); }
+        const_iterator begin() const { return items.begin(); }
+        iterator end(){ return items.end(); }
+        const_iterator end() const { return items.end(); }
+        reverse_iterator rbegin() { return reverse_iterator(end()); }
+        const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+        reverse_iterator rend() { return reverse_iterator(begin()); }
+        const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+    };
+}
+#endif  // INCLUDE_MATYA_MAP_AS_VEC_HPP_

--- a/include/scr_constants.h
+++ b/include/scr_constants.h
@@ -2,6 +2,6 @@
 namespace scr_constants {
     constexpr char TOOL_NAME[] = "Simple Command Runner";
     constexpr char AUTHOR[] = "matyalatte";
-    constexpr char VERSION[] = "0.4.0";
-    constexpr int VERSION_INT = 400;
+    constexpr char VERSION[] = "0.4.1";
+    constexpr int VERSION_INT = 401;
 }

--- a/scr_schema.json
+++ b/scr_schema.json
@@ -1,0 +1,237 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "recommended": { "$ref": "#/definitions/types/version" },
+    "minimum_required": { "$ref": "#/definitions/types/version" },
+    "gui": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "label": { "type": "string" },
+          "command": { "type": "string" },
+          "window_name": { "type": "string" },
+          "button": { "type": "string" },
+          "show_last_line": { "type": "boolean" },
+          "check_exit_code": { "type": "boolean" },
+          "exit_success": { "type": "integer" },
+          "components": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "static_text",
+                    "file",
+                    "folder",
+                    "choice",
+                    "check",
+                    "check_array",
+                    "text",
+                    "int",
+                    "float"
+                  ]
+                },
+                "label": { "type": "string" },
+                "id": { "type": "string" },
+                "add_quotes": { "type": "boolean" }
+              },
+              "allOf": [
+                { "$ref": "#/definitions/components/file" },
+                { "$ref": "#/definitions/components/folder_or_text" },
+                { "$ref": "#/definitions/components/check" },
+                { "$ref": "#/definitions/components/int" },
+                { "$ref": "#/definitions/components/float" },
+                { "$ref": "#/definitions/components/choice" },
+                { "$ref": "#/definitions/components/check_array" }
+              ],
+              "required": [ "type", "label" ]
+            }
+          }
+        },
+        "required": [
+          "label",
+          "command",
+          "components"
+        ]
+      }
+    },
+    "help": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [ "url", "file" ]
+          },
+          "label": { "type": "string" }
+        },
+        "required": [ "type", "label" ],
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "type": { "const": "url" }
+              }
+            },
+            "then": {
+              "properties": {
+                "url": { "type": "string" },
+                "path": { "type": "null" }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": { "const": "file" }
+              }
+            },
+            "then": {
+              "properties": {
+                "url": { "type": "null" },
+                "path": { "type": "string" }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "required": [ "gui" ],
+  "definitions": {
+    "types": {
+      "version": {
+        "type": "string",
+        "pattern": "^[.0-9]+$",
+        "minLength": 1,
+        "maxLength": 8
+      },
+      "str_array": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "components": {
+      "file": {
+        "if": {
+          "properties": {
+            "type": { "const": "file"}
+          }
+        },
+        "then": {
+          "properties": {
+            "extension": { "type": "string" },
+            "empty_message": { "type": "string" },
+            "default": { "type": "string" },
+            "tooltip": { "type": "string" }
+          }
+        }
+      },
+      "folder_or_text": {
+        "if": {
+          "properties": {
+            "type": { "enum": [ "folder", "text" ] }
+          }
+        },
+        "then": {
+          "properties": {
+            "empty_message": { "type": "string" },
+            "default": { "type": "string" },
+            "tooltip": { "type": "string" }
+          }
+        }
+      },
+      "check": {
+        "if": {
+          "properties": {
+            "type": { "const": "check"}
+          }
+        },
+        "then": {
+          "properties": {
+            "default": { "type": "boolean" },
+            "tooltip": { "type": "string" },
+            "value": { "type": "string" }
+          }
+        }
+      },
+      "int": {
+        "if": {
+          "properties": {
+            "type": { "const": "int"}
+          }
+        },
+        "then": {
+          "properties": {
+            "min": { "type": "integer" },
+            "max": { "type": "integer" },
+            "inc": { "type": "integer" },
+            "wrap": { "type": "boolean" },
+            "default": { "type": "integer" },
+            "tooltip": { "type": "string" }
+          }
+        }
+      },
+      "float": {
+        "if": {
+          "properties": {
+            "type": { "const": "float"}
+          }
+        },
+        "then": {
+          "properties": {
+            "min": { "type": "number" },
+            "max": { "type": "number" },
+            "inc": { "type": "number" },
+            "wrap": { "type": "boolean" },
+            "digits": { "type": "integer" },
+            "default": { "type": "number" },
+            "tooltip": { "type": "string" }
+          }
+        }
+      },
+      "choice": {
+        "if": {
+          "properties": {
+            "type": { "const": "choice"}
+          }
+        },
+        "then": {
+          "properties": {
+            "default": { "type": "integer" },
+            "tooltip": { "type": "string" },
+            "item": { "$ref": "#/definitions/types/str_array" },
+            "value": { "$ref": "#/definitions/types/str_array" }
+          }
+        }
+      },
+      "check_array": {
+        "if": {
+          "properties": {
+            "type": { "const": "check_array"}
+          }
+        },
+        "then": {
+          "properties": {
+            "default": {
+              "type": "array",
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "tooltip": { "$ref": "#/definitions/types/str_array" },
+            "item": { "$ref": "#/definitions/types/str_array" },
+            "value": { "$ref": "#/definitions/types/str_array" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -4,10 +4,10 @@
 Component::Component(const nlohmann::json& j, bool has_string) {
     m_widget = nullptr;
     m_has_string = has_string;
-    m_label = wxString::FromUTF8(j["label"]);
+    m_label = wxString::FromUTF8(j["label"].get<std::string>());
     m_id = j.value("id", "");
     if (m_id == "") {
-        size_t hash = std::hash<std::string>()(j["label"]);
+        size_t hash = std::hash<std::string>()(j["label"].get<std::string>());
         m_id = "_" + std::to_string(hash);
     }
     m_add_quotes = j.value("add_quotes", false);
@@ -35,7 +35,7 @@ bool Component::HasString() {
 
 Component* Component::PutComponent(wxWindow* panel, wxBoxSizer* sizer, const nlohmann::json& j) {
     Component* comp = nullptr;
-    std::string type = j["type"];
+    std::string type = j["type"].get<std::string>();
     if (type == "static_text") {  // statc text
         comp = new StaticText(panel, sizer, j);
     } else if (type == "file") {  // file picker
@@ -78,7 +78,7 @@ StringComponentBase::StringComponentBase(
     : Component(j, HAS_STRING) {
     wxStaticText* text = new wxStaticText(panel, wxID_ANY, m_label);
     if (j.contains("tooltip") && !j["tooltip"].is_array()) {
-        text->SetToolTip(wxString::FromUTF8(j["tooltip"]));
+        text->SetToolTip(wxString::FromUTF8(j["tooltip"].get<std::string>()));
     }
     sizer->Add(text, 0, DEFAULT_SIZER_FLAG, 3);
 }
@@ -112,7 +112,7 @@ wxString FilePicker::GetRawString() {
 
 void FilePicker::SetConfig(const nlohmann::json& config) {
     if (config.contains("str") && config["str"].is_string()) {
-        wxString str = wxString::FromUTF8(config["str"]);
+        wxString str = wxString::FromUTF8(config["str"].get<std::string>());
         static_cast<CustomFilePicker*>(m_widget)->SetPath(str);
         static_cast<CustomFilePicker*>(m_widget)->SetInitialDirectory(wxPathOnly(str));
     }
@@ -140,7 +140,7 @@ wxString DirPicker::GetRawString() {
 
 void DirPicker::SetConfig(const nlohmann::json& config) {
     if (config.contains("str") && config["str"].is_string()) {
-        wxString str = wxString::FromUTF8(config["str"]);
+        wxString str = wxString::FromUTF8(config["str"].get<std::string>());
         static_cast<CustomDirPicker*>(m_widget)->SetPath(str);
         static_cast<CustomDirPicker*>(m_widget)->SetInitialDirectory(str);
     }
@@ -150,7 +150,7 @@ void DirPicker::SetConfig(const nlohmann::json& config) {
 Choice::Choice(wxWindow* panel, wxBoxSizer* sizer, const nlohmann::json& j)
     : StringComponentBase(panel, sizer, j) {
     wxArrayString wxitems;
-    std::vector<std::string> items = j["item"];
+    std::vector<std::string> items = j["item"].get<std::vector<std::string>>();
     std::for_each(items.begin(), items.end(), [&](std::string i) {
         wxitems.Add(wxString::FromUTF8(i));
         });
@@ -159,9 +159,9 @@ Choice::Choice(wxWindow* panel, wxBoxSizer* sizer, const nlohmann::json& j)
     choice->SetSelection(j.value("default", 0) % items.size());
 
     if (j.contains("value") && j["value"].size() == j["item"].size()) {
-        SetValues(j["value"]);
+        SetValues(j["value"].get<std::vector<std::string>>());
     } else {
-        SetValues(j["item"]);
+        SetValues(j["item"].get<std::vector<std::string>>());
     }
     choice->SetToolTip(wxString::FromUTF8(j.value("tooltip", "")));
     m_widget = choice;
@@ -174,7 +174,7 @@ wxString Choice::GetRawString() {
 
 void Choice::SetConfig(const nlohmann::json& config) {
     if (config.contains("int") && config["int"].is_number() && config["int"] < m_values.size()) {
-        static_cast<wxChoice*>(m_widget)->SetSelection(config["int"]);
+        static_cast<wxChoice*>(m_widget)->SetSelection(config["int"].get<int>());
     }
 }
 
@@ -220,20 +220,20 @@ CheckArray::CheckArray(wxWindow* panel, wxBoxSizer* sizer, const nlohmann::json&
     std::vector<wxCheckBox*>* checks = new std::vector<wxCheckBox*>();
     for (int i = 0; i < j["item"].size(); i++) {
         wxCheckBox* check = new wxCheckBox(panel, wxID_ANY,
-                           wxString::FromUTF8(j["item"][i]));
+                           wxString::FromUTF8(j["item"][i].get<std::string>()));
         if (j.contains("default")) {
-            check->SetValue(j["default"][i]);
+            check->SetValue(j["default"][i].get<bool>());
         }
         if (j.contains("tooltip")) {
-            check->SetToolTip(wxString::FromUTF8(j["tooltip"][i]));
+            check->SetToolTip(wxString::FromUTF8(j["tooltip"][i].get<std::string>()));
         }
         checks->push_back(check);
         sizer->Add(check, 0, DEFAULT_SIZER_FLAG, 3 + 10 * (i + 1 == j["item"].size()));
     }
     if (j.contains("value")) {
-        SetValues(j["value"]);
+        SetValues(j["value"].get<std::vector<std::string>>());
     } else {
-        SetValues(j["item"]);
+        SetValues(j["item"].get<std::vector<std::string>>());
     }
     m_widget = checks;
 }
@@ -289,7 +289,7 @@ wxString TextBox::GetRawString() {
 
 void TextBox::SetConfig(const nlohmann::json& config) {
     if (config.contains("str") && config["str"].is_string()) {
-        wxString str = wxString::FromUTF8(config["str"]);
+        wxString str = wxString::FromUTF8(config["str"].get<std::string>());
         static_cast<CustomTextCtrl*>(m_widget)->UpdateText(str);
     }
 }

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -35,7 +35,7 @@ bool Component::HasString() {
 
 Component* Component::PutComponent(wxWindow* panel, wxBoxSizer* sizer, const nlohmann::json& j) {
     Component* comp = nullptr;
-    int type = j["type"].get<int>();
+    int type = j["type_int"].get<int>();
     switch (type) {
         case COMP_STATIC_TEXT:
             comp = new StaticText(panel, sizer, j);

--- a/src/component.cpp
+++ b/src/component.cpp
@@ -35,34 +35,46 @@ bool Component::HasString() {
 
 Component* Component::PutComponent(wxWindow* panel, wxBoxSizer* sizer, const nlohmann::json& j) {
     Component* comp = nullptr;
-    std::string type = j["type"].get<std::string>();
-    if (type == "static_text") {  // statc text
-        comp = new StaticText(panel, sizer, j);
-    } else if (type == "file") {  // file picker
-        comp = new FilePicker(panel, sizer, j);
-    } else if (type == "folder") {  // dir picker
-        comp = new DirPicker(panel, sizer, j);
-    } else if (type == "choice") {  // choice
-        comp = new Choice(panel, sizer, j);
-    } else if (type == "check") {  // checkbox
-        comp = new CheckBox(panel, sizer, j);
-    } else if (type == "check_array") {  // checkArray
-        comp = new CheckArray(panel, sizer, j);
-    } else if (type == "text") {  // text box
-        comp = new TextBox(panel, sizer, j);
-    } else if (type == "int") {  // int picker
-        comp = new IntPicker(panel, sizer, j);
-    } else if (type == "float") {  // int picker
-        comp = new FloatPicker(panel, sizer, j);
-    } else {
-        std::cout << "Unknown component type detected. (" + type << ")" << std::endl;
+    int type = j["type"].get<int>();
+    switch (type) {
+        case COMP_STATIC_TEXT:
+            comp = new StaticText(panel, sizer, j);
+            break;
+        case COMP_FILE:
+            comp = new FilePicker(panel, sizer, j);
+            break;
+        case COMP_FOLDER:
+            comp = new DirPicker(panel, sizer, j);
+            break;
+        case COMP_CHOICE:
+            comp = new Choice(panel, sizer, j);
+            break;
+        case COMP_CHECK:
+            comp = new CheckBox(panel, sizer, j);
+            break;
+        case COMP_CHECK_ARRAY:
+            comp = new CheckArray(panel, sizer, j);
+            break;
+        case COMP_TEXT:
+            comp = new TextBox(panel, sizer, j);
+            break;
+        case COMP_INT:
+            comp = new IntPicker(panel, sizer, j);
+            break;
+        case COMP_FLOAT:
+            comp = new FloatPicker(panel, sizer, j);
+            break;
+        default:
+            std::string msg = "Unknown component type detected. (" + std::to_string(type) + ")";
+            throw std::runtime_error(msg);
+            break;
     }
     return comp;
 }
 
-const bool HAS_STRING = true;
-const bool NOT_STRING = false;
-const int DEFAULT_SIZER_FLAG = wxFIXED_MINSIZE | wxALIGN_LEFT | wxBOTTOM;
+static const bool HAS_STRING = true;
+static const bool NOT_STRING = false;
+static const int DEFAULT_SIZER_FLAG = wxFIXED_MINSIZE | wxALIGN_LEFT | wxBOTTOM;
 
 // Static Text
 StaticText::StaticText(wxWindow* panel, wxBoxSizer* sizer, const nlohmann::json& j)
@@ -339,7 +351,6 @@ IntPicker::IntPicker(wxWindow* panel, wxBoxSizer* sizer, const nlohmann::json& j
     double val = j.value("default", 0.0);
     m_picker->SetValue(val);
 }
-
 
 FloatPicker::FloatPicker(wxWindow* panel, wxBoxSizer* sizer, const nlohmann::json& j)
     : NumPickerBase(panel, sizer, j) {

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -233,7 +233,7 @@ namespace json_utils {
         sub_definition["command"] = splitted_cmd;
     }
 
-    static const std::map<std::string, int> COMPTYPE_TO_INT_MAP = {
+    static const matya::map_as_vec<int> COMPTYPE_TO_INT = {
         {"static_text", COMP_STATIC_TEXT},
         {"file", COMP_FILE},
         {"folder", COMP_FOLDER},
@@ -249,12 +249,6 @@ namespace json_utils {
         {"integer", COMP_INT},
         {"float", COMP_FLOAT},
     };
-
-    static int ComptypeToInt(const std::string& type) {
-        if (COMPTYPE_TO_INT_MAP.count(type) == 0)
-            return COMP_UNKNOWN;
-        return COMPTYPE_TO_INT_MAP.at(type);
-    }
 
     void CheckSubDefinition(nlohmann::json& sub_definition) {
         // check is_string
@@ -284,7 +278,7 @@ namespace json_utils {
             CheckJsonType(c, "type", JsonType::STRING, label);
             KeyToSingular(c, "default");
             std::string type_str = c["type"].get<std::string>();
-            int type = ComptypeToInt(type_str);
+            int type = COMPTYPE_TO_INT.get(type_str, COMP_UNKNOWN);
             c["type"] = type;
 
             switch (type) {

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -254,8 +254,10 @@ namespace json_utils {
                            || comp_ids[non_id_comp] != "")) {
                     non_id_comp++;
                 }
-                if (non_id_comp >= comp_size)
-                    throw std::runtime_error("The command requires more components for arguments; " + cmd_str);
+                if (non_id_comp >= comp_size) {
+                    throw std::runtime_error(
+                        "The command requires more components for arguments; " + cmd_str);
+                }
                 j = non_id_comp;
                 non_id_comp++;
             }
@@ -269,7 +271,7 @@ namespace json_utils {
             if (sub_definition["components"][j]["type_int"] == COMP_STATIC_TEXT)
                 continue;
             bool found = false;
-            for (int id: cmd_int_ids)
+            for (int id : cmd_int_ids)
                 if (id == j) { found = true; break; }
             if (!found) {
                 throw std::runtime_error("[\"commponents\"][" + std::to_string(j)
@@ -296,7 +298,7 @@ namespace json_utils {
         {"float", COMP_FLOAT},
     };
 
-    // validate one of definitions (["gui"][i]) and edit them to 
+    // validate one of definitions (["gui"][i]) and store parsed info
     void CheckSubDefinition(nlohmann::json& sub_definition) {
         // check is_string
         CheckJsonType(sub_definition, "label", JsonType::STRING);

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -165,14 +165,14 @@ namespace json_utils {
 
     void CheckArraySize(nlohmann::json& c, const std::string& key) {
         if (c.contains(key) && (c[key].size() != c["item"].size())) {
-            std::string label = c["label"];
+            std::string label = c["label"].get<std::string>();
             Raise(GetLabel(label, key) + " and " +
                 GetLabel(label, "item") + " should have the same size.");
         }
     }
 
     void CheckItemsValues(nlohmann::json& c) {
-        std::string label = c["label"];
+        std::string label = c["label"].get<std::string>();
         KeyToSingular(c, "item");
         CheckJsonType(c, "item", JsonType::STR_ARRAY, label);
         KeyToSingular(c, "value");
@@ -223,12 +223,12 @@ namespace json_utils {
         CheckContain(sub_definition, COMMAND, "");
         CheckJsonType(sub_definition, "command_ids", JsonType::STR_ARRAY, "", CAN_SKIP);
         if (sub_definition[COMMAND].is_string()) {
-            sub_definition[COMMAND] = SplitString(sub_definition[COMMAND], { '%' });
+            sub_definition[COMMAND] = SplitString(sub_definition[COMMAND].get<std::string>(), { '%' });
         } else {
             CheckJsonType(sub_definition, COMMAND, JsonType::STR_ARRAY);
         }
 
-        std::vector<std::string> cmd = sub_definition[COMMAND];
+        std::vector<std::string> cmd = sub_definition[COMMAND].get<std::vector<std::string>>();
         std::vector<std::string> cmd_ids = std::vector<std::string>(0);
         std::vector<std::string> splitted_cmd = std::vector<std::string>(0);
         bool store_ids = false;
@@ -275,7 +275,7 @@ namespace json_utils {
         for (nlohmann::json& c : sub_definition[COMPONENTS]) {
             // check if type and label exist
             CheckJsonType(c, "label", JsonType::STRING, COMPONENTS);
-            std::string label = c["label"];
+            std::string label = c["label"].get<std::string>();
             CheckJsonType(c, "type", JsonType::STRING, label);
             CorrectValue(c, "type", "dir", "folder");
             CorrectValue(c, "type", "combo", "choice");
@@ -283,7 +283,7 @@ namespace json_utils {
             CorrectValue(c, "type", "text_box", "text");
             CorrectValue(c, "type", "integer", "int");
             KeyToSingular(c, "default");
-            std::string type = c["type"];
+            std::string type = c["type"].get<std::string>();
 
             if (type == "file") {
                 CheckJsonType(c, "extention", JsonType::STRING, label, CAN_SKIP);
@@ -334,13 +334,13 @@ namespace json_utils {
 
 
             if (c.contains("id")) {
-                std::string id = c["id"];
+                std::string id = c["id"].get<std::string>();
                 if (id == "") {
                     Raise(GetLabel(label, "id") + " should NOT be an empty string.");
                 } else if (id[0] == "_"[0]) {
                     Raise(GetLabel(label, "id") + " should NOT start with '_'.");
                 }
-                comp_ids.push_back(c["id"]);
+                comp_ids.push_back(id);
             } else {
                 comp_ids.push_back("");
             }
@@ -374,7 +374,7 @@ namespace json_utils {
         CorrectKey(definition, k + "_version", k);
         if (definition.contains(k)) {
             CheckJsonType(definition, k, JsonType::STRING);
-            int recom_int = VersionStringToInt(definition[k]);
+            int recom_int = VersionStringToInt(definition[k].get<std::string>());
             CheckJsonType(definition, "not_" + k, JsonType::BOOLEAN, "", CAN_SKIP);
             definition["not_" + k] = scr_constants::VERSION_INT != recom_int;
         }
@@ -382,7 +382,7 @@ namespace json_utils {
         CorrectKey(definition, k + "_version", k);
         if (definition.contains(k)) {
             CheckJsonType(definition, k, JsonType::STRING);
-            std::string required = definition[k];
+            std::string required = definition[k].get<std::string>();
             int required_int = VersionStringToInt(required);
             if (scr_constants::VERSION_INT < required_int) {
                 std::string msg = "Version " + required + " is required.";
@@ -403,7 +403,7 @@ namespace json_utils {
         for (nlohmann::json h : definition["help"]) {
             CheckJsonType(h, "type", JsonType::STRING);
             CheckJsonType(h, "label", JsonType::STRING);
-            std::string type = h["type"];
+            std::string type = h["type"].get<std::string>();
             if (type == "url") {
                 CheckJsonType(h, "url", JsonType::STRING);
             } else if (type == "file") {

--- a/src/json_utils.cpp
+++ b/src/json_utils.cpp
@@ -126,15 +126,16 @@ namespace json_utils {
         nlohmann::json def = {
                 {"label", "Default GUI"},
     #ifdef _WIN32
-                {"command", {"dir"} },
+                {"command", "dir" },
+                {"command_splitted", { "dir" } },
                 {"button", "run 'dir'"},
     #else
-                {"command", {"ls"} },
+                {"command", "ls" },
+                {"command_splitted", { "ls" } },
                 {"button", "run 'ls'"},
     #endif
-                {"command_ids", nlohmann::json::array({})},
                 {"components", nlohmann::json::array({})},
-                {"component_ids", nlohmann::json::array({})}
+                {"command_ids", nlohmann::json::array({})}
         };
         return def;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -81,7 +81,7 @@ enum Commands: int {
     CMD_MAX
 };
 
-const std::map<wxString, int> CMD_TO_INT_MAP = {
+const matya::map_as_vec<int> CMD_TO_INT = {
     {"merge", CMD_MERGE},
     {"m", CMD_MERGE},
     {"split", CMD_SPLIT},
@@ -89,12 +89,6 @@ const std::map<wxString, int> CMD_TO_INT_MAP = {
     {"help", CMD_HELP},
     {"h", CMD_HELP},
 };
-
-int CmdToInt(const wxString& command) {
-    if (CMD_TO_INT_MAP.count(command) == 0)
-        return CMD_UNKNOWN;
-    return CMD_TO_INT_MAP.at(command);
-}
 
 wxString GetFullPath(const wxString& path) {
     wxFileName fn(path);
@@ -120,7 +114,7 @@ int main(int argc, char* argv[]) {
 
     wxString command_str = (argv[1]);
     command_str.Replace("-", "");
-    int command = CmdToInt(command_str);
+    int command = CMD_TO_INT.get(command_str.c_str(), CMD_UNKNOWN);
     if (command == CMD_UNKNOWN) {
         PrintUsage();
         std::cerr << "Error: Unsupported command detected. (" << command_str << ")" << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
 #include "main_frame.h"
-#include <map>
 
 // Main
 class MainApp : public wxApp {
@@ -74,7 +73,7 @@ void PrintUsage() {
     std::cout << usage << std::endl;
 }
 
-enum COMMANDS: int {
+enum Commands: int {
     CMD_UNKNOWN = 0,
     CMD_MERGE,
     CMD_SPLIT,
@@ -82,7 +81,7 @@ enum COMMANDS: int {
     CMD_MAX
 };
 
-std::map <wxString, int> CMD_TO_INT_MAP = {
+const std::map<wxString, int> CMD_TO_INT_MAP = {
     {"merge", CMD_MERGE},
     {"m", CMD_MERGE},
     {"split", CMD_SPLIT},
@@ -94,7 +93,7 @@ std::map <wxString, int> CMD_TO_INT_MAP = {
 int CmdToInt(const wxString& command) {
     if (CMD_TO_INT_MAP.count(command) == 0)
         return CMD_UNKNOWN;
-    return CMD_TO_INT_MAP[command];
+    return CMD_TO_INT_MAP.at(command);
 }
 
 wxString GetFullPath(const wxString& path) {

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -2,7 +2,9 @@
 
 // Main window
 MainFrame::MainFrame(nlohmann::json definition, nlohmann::json config)
-    : wxFrame(nullptr, wxID_ANY, scr_constants::TOOL_NAME) {
+    : wxFrame(nullptr, wxID_ANY, scr_constants::TOOL_NAME,
+              wxDefaultPosition, wxDefaultSize,
+              wxDEFAULT_FRAME_STYLE & ~wxRESIZE_BORDER & ~wxMAXIMIZE_BOX) {
     SetUp();
     if (definition.empty()) {
         if (wxFileExists("gui_definition.json")) {
@@ -119,8 +121,6 @@ void MainFrame::CreateFrame() {
     m_run_button->GetSize(nullptr, &button_height);
     SetSize(GetSize() + wxSize(0, button_height));
 #endif
-
-    SetWindowStyleFlag(wxDEFAULT_FRAME_STYLE & ~wxRESIZE_BORDER & ~wxMAXIMIZE_BOX);
 }
 
 void MainFrame::JsonLoadFailed(const std::string& msg, nlohmann::json& definition) {

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -349,7 +349,9 @@ void MainFrame::UpdateFrame(wxCommandEvent& event) {
 
 void MainFrame::UpdatePanel() {
     wxString label = wxString::FromUTF8(m_sub_definition["label"].get<std::string>());
-    *m_ostream << "[UpdatePanel] " << label << std::endl;
+    *m_ostream << "[UpdatePanel] Lable: " << label << std::endl;
+    wxString cmd_str = wxString::FromUTF8(m_sub_definition["command_str"].get<std::string>());
+    *m_ostream << "[UpdatePanel] Command: " << cmd_str << std::endl;
     wxString window_name = wxString::FromUTF8(
         m_sub_definition.value("window_name", "Simple Command Runner"));
     SetLabel(window_name);

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -214,9 +214,12 @@ constexpr char CMD_ID_CURRENT_DIR[] = "__CWD__";
 
 // Make command string
 wxString MainFrame::GetCommand() {
-    std::vector<std::string> cmd_ary = m_sub_definition["command"].get<std::vector<std::string>>();
-    std::vector<std::string> cmd_ids = m_sub_definition["command_ids"].get<std::vector<std::string>>();
-    std::vector<std::string> comp_ids = m_sub_definition["component_ids"].get<std::vector<std::string>>();
+    std::vector<std::string> cmd_ary =
+        m_sub_definition["command"].get<std::vector<std::string>>();
+    std::vector<std::string> cmd_ids =
+        m_sub_definition["command_ids"].get<std::vector<std::string>>();
+    std::vector<std::string> comp_ids =
+        m_sub_definition["component_ids"].get<std::vector<std::string>>();
 
     std::vector<wxString> comp_strings = std::vector<wxString>(m_components.size());
     for (int i = 0; i < m_components.size(); i++) {
@@ -387,7 +390,8 @@ void MainFrame::UpdatePanel() {
     m_panel = new wxPanel(this);
 
     // put components
-    std::vector<nlohmann::json> comp = m_sub_definition["components"].get<std::vector<nlohmann::json>>();
+    std::vector<nlohmann::json> comp =
+        m_sub_definition["components"].get<std::vector<nlohmann::json>>();
     m_components.clear();
     m_components.shrink_to_fit();
     Component* new_comp = nullptr;

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -209,17 +209,12 @@ void MainFrame::ShowSuccessDialog(const wxString& msg) {
     dialog->Destroy();
 }
 
-constexpr char CMD_ID_PERCENT[] = "";
-constexpr char CMD_ID_CURRENT_DIR[] = "__CWD__";
-
 // Make command string
 wxString MainFrame::GetCommand() {
     std::vector<std::string> cmd_ary =
-        m_sub_definition["command"].get<std::vector<std::string>>();
-    std::vector<std::string> cmd_ids =
-        m_sub_definition["command_ids"].get<std::vector<std::string>>();
-    std::vector<std::string> comp_ids =
-        m_sub_definition["component_ids"].get<std::vector<std::string>>();
+        m_sub_definition["command_splitted"].get<std::vector<std::string>>();
+    std::vector<int> cmd_ids =
+        m_sub_definition["command_ids"].get<std::vector<int>>();
 
     std::vector<wxString> comp_strings = std::vector<wxString>(m_components.size());
     for (int i = 0; i < m_components.size(); i++) {
@@ -227,39 +222,14 @@ wxString MainFrame::GetCommand() {
     }
 
     wxString cmd = wxString::FromUTF8(cmd_ary[0]);
-    int comp_size = comp_ids.size();
-    int non_id_comp = 0;
     for (int i = 0; i < cmd_ids.size(); i++) {
-        std::string id = cmd_ids[i];
-        int j = -1;
-        if (id == "") {
-            j = comp_size;
-        } else if (id == CMD_ID_PERCENT) {
+        int id = cmd_ids[i];
+        if (id == CMD_ID_PERCENT) {
             cmd += "%";
         } else if (id == CMD_ID_CURRENT_DIR) {
             cmd += wxGetCwd();
         } else {
-            for (j = 0; j < comp_size; j++) {
-                if (id == comp_ids[j]) {
-                    break;
-                }
-            }
-        }
-        if (j >= comp_size) {
-            while (non_id_comp < comp_size &&
-                  (!m_components[non_id_comp]->HasString() || comp_ids[non_id_comp] != "")) {
-                non_id_comp++;
-            }
-            j = non_id_comp;
-            if (non_id_comp >= comp_size) {
-                *m_ostream << "[RunCommand] Warning: "
-                           << "The command requires more components for arguments."
-                           << std::endl;
-            }
-            non_id_comp++;
-        }
-        if (j >= 0 && j < comp_size) {
-            cmd += comp_strings[j];
+            cmd += comp_strings[id];
         }
         if (i + 1 < cmd_ary.size()) {
             cmd += wxString::FromUTF8(cmd_ary[i + 1]);

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -64,10 +64,10 @@ nlohmann::json MainFrame::LoadJson(const std::string& file, bool is_definition) 
     try {
         json = json_utils::LoadJson(file);
     }
-    catch (nlohmann::json::exception& e) {
+    catch (const nlohmann::json::exception& e) {
         if (is_definition) JsonLoadFailed(e.what(), json);
     }
-    catch (std::exception& e) {
+    catch (const std::exception& e) {
         if (is_definition) JsonLoadFailed(e.what(), json);
     }
     return json;
@@ -147,7 +147,7 @@ void MainFrame::CheckDefinition(nlohmann::json& definition) {
             }
         }
     }
-    catch(std::exception& e) {
+    catch(const std::exception& e) {
         JsonLoadFailed(std::string(e.what()), definition);
         return;
     }
@@ -157,8 +157,8 @@ void MainFrame::CheckDefinition(nlohmann::json& definition) {
         try {
             json_utils::CheckHelpURLs(definition);
         }
-        catch(std::exception& e) {
-            msg = "Fialed to load help URLs (" + std::string(e.what()) + ")";
+        catch(const std::exception& e) {
+            msg = "Failed to load help URLs (" + std::string(e.what()) + ")";
             wxString wxmsg = wxString::FromUTF8(msg);
             *m_ostream << "[LoadDefinition] Error: " << wxmsg << std::endl;
             ShowErrorDialog(wxmsg);
@@ -170,8 +170,8 @@ void MainFrame::CheckDefinition(nlohmann::json& definition) {
     try {
         json_utils::CheckDefinition(definition);
     }
-    catch (std::exception& e) {
-        msg = "Fialed to load gui_definition.json (" + std::string(e.what()) + ")";
+    catch (const std::exception& e) {
+        msg = "Failed to load gui_definition.json (" + std::string(e.what()) + ")";
         JsonLoadFailed(msg, definition);
         return;
     }

--- a/src/main_frame.cpp
+++ b/src/main_frame.cpp
@@ -81,7 +81,7 @@ void MainFrame::CreateFrame() {
     if (m_definition["gui"].size() > 1) {
         for (int i = 0; i < m_definition["gui"].size(); i++) {
             menu_file->Append(wxID_HIGHEST + i + 1,
-                wxString::FromUTF8(m_definition["gui"][i]["label"]));
+                wxString::FromUTF8(m_definition["gui"][i]["label"].get<std::string>()));
             menu_file->Bind(wxEVT_MENU,
                 &MainFrame::UpdateFrame, this, wxID_HIGHEST + i + 1);
         }
@@ -96,7 +96,7 @@ void MainFrame::CreateFrame() {
 
         for (int i = 0; i < m_definition["help"].size(); i++) {
             menu_help->Append(wxID_HIGHEST + i + 1 + m_definition["gui"].size(),
-                wxString::FromUTF8(m_definition["help"][i]["label"]));
+                wxString::FromUTF8(m_definition["help"][i]["label"].get<std::string>()));
             menu_help->Bind(wxEVT_MENU,
                 &MainFrame::OpenURL, this, wxID_HIGHEST + i + 1 + m_definition["gui"].size());
         }
@@ -140,7 +140,7 @@ void MainFrame::CheckDefinition(nlohmann::json& definition) {
         json_utils::CheckVersion(definition);
         std::string key = "recommended";
         if (definition.contains(key)) {
-            std::string version = definition[key];
+            std::string version = definition[key].get<std::string>();
             if (definition["not_" + key]) {
                 msg = "Version " + version + " is " + key + ".";
                 *m_ostream << "[LoadDefinition] Warning: " << msg << std::endl;
@@ -214,9 +214,9 @@ constexpr char CMD_ID_CURRENT_DIR[] = "__CWD__";
 
 // Make command string
 wxString MainFrame::GetCommand() {
-    std::vector<std::string> cmd_ary = m_sub_definition["command"];
-    std::vector<std::string> cmd_ids = m_sub_definition["command_ids"];
-    std::vector<std::string> comp_ids = m_sub_definition["component_ids"];
+    std::vector<std::string> cmd_ary = m_sub_definition["command"].get<std::vector<std::string>>();
+    std::vector<std::string> cmd_ids = m_sub_definition["command_ids"].get<std::vector<std::string>>();
+    std::vector<std::string> comp_ids = m_sub_definition["component_ids"].get<std::vector<std::string>>();
 
     std::vector<wxString> comp_strings = std::vector<wxString>(m_components.size());
     for (int i = 0; i < m_components.size(); i++) {
@@ -311,12 +311,12 @@ void MainFrame::ClickButton(wxCommandEvent& event) {
 void MainFrame::OpenURL(wxCommandEvent& event) {
     size_t id = event.GetId() - 1 - wxID_HIGHEST - m_definition["gui"].size();
     nlohmann::json help = m_definition["help"][id];
-    std::string type = help["type"];
+    std::string type = help["type"].get<std::string>();
     wxString url = "";
     std::string tag;
     try {
         if (type == "url") {
-            url = wxString::FromUTF8(help["url"]);
+            url = wxString::FromUTF8(help["url"].get<std::string>());
             tag = "[OpenURL] ";
             int pos = url.Find("://");
             if (pos !=wxNOT_FOUND) {
@@ -334,7 +334,7 @@ void MainFrame::OpenURL(wxCommandEvent& event) {
                 url = "https://" + url;
             }
         } else if (type == "file") {
-            url = wxString::FromUTF8(help["path"]);
+            url = wxString::FromUTF8(help["path"].get<std::string>());
             tag = "[OpenFile] ";
             if (!wxFileExists(url) && !wxDirExists(url)) {
                 wxString msg = "File does not exist. (" + url + ")";
@@ -375,7 +375,7 @@ void MainFrame::UpdateFrame(wxCommandEvent& event) {
 }
 
 void MainFrame::UpdatePanel() {
-    wxString label = wxString::FromUTF8(m_sub_definition["label"]);
+    wxString label = wxString::FromUTF8(m_sub_definition["label"].get<std::string>());
     *m_ostream << "[UpdatePanel] " << label << std::endl;
     wxString window_name = wxString::FromUTF8(
         m_sub_definition.value("window_name", "Simple Command Runner"));
@@ -387,7 +387,7 @@ void MainFrame::UpdatePanel() {
     m_panel = new wxPanel(this);
 
     // put components
-    std::vector<nlohmann::json> comp = m_sub_definition["components"];
+    std::vector<nlohmann::json> comp = m_sub_definition["components"].get<std::vector<nlohmann::json>>();
     m_components.clear();
     m_components.shrink_to_fit();
     Component* new_comp = nullptr;

--- a/tests/json_check/main.cpp
+++ b/tests/json_check/main.cpp
@@ -63,6 +63,18 @@ TEST(JsonCheckTest, checkGUISuccess2) {
     json_utils::CheckDefinition(test_json);
 }
 
+TEST(JsonCheckTest, checkGUISuccess3) {
+    nlohmann::json test_json = GetTestJson();
+    test_json["gui"][0] = test_json["gui"][1];
+    json_utils::CheckDefinition(test_json);
+}
+
+TEST(JsonCheckTest, checkGUISuccess4) {
+    nlohmann::json test_json = GetTestJson();
+    test_json["gui"][0] = test_json["gui"][2];
+    json_utils::CheckDefinition(test_json);
+}
+
 void CheckGUIError(nlohmann::json test_json, const char* expected) {
     try {
         json_utils::CheckDefinition(test_json);
@@ -115,6 +127,26 @@ TEST(JsonCheckTest, checkGUIFail7) {
     test_json["gui"][0]["components"][5]["default"] = nlohmann::json::array();
     CheckGUIError(test_json,
         "['options']['default'] and ['options']['item'] should have the same size.");
+}
+
+TEST(JsonCheckTest, checkGUIFail8) {
+    nlohmann::json test_json = GetTestJson();
+    test_json["gui"][0]["components"].erase(1);
+    CheckGUIError(test_json,
+        "The command requires more components for arguments;"
+        " echo file: __comp1__ & echo folder: __comp2__ & echo choice: __comp3__ &"
+        " echo check: __comp4__ & echo check_array: __comp5__ & echo textbox: __comp6__ &"
+        " echo int: __comp7__ & echo float: __comp???__");
+}
+
+TEST(JsonCheckTest, checkGUIFail9) {
+    nlohmann::json test_json = GetTestJson();
+    test_json["gui"][0]["components"][1]["id"] = "aaa";
+    CheckGUIError(test_json,
+        "The ID of [\"commponents\"][1] is unused in the command;"
+        " echo file: __comp2__ & echo folder: __comp3__ & echo choice: __comp4__"
+        " & echo check: __comp5__ & echo check_array: __comp6__ & echo textbox: __comp7__"
+        " & echo int: __comp8__ & echo float: __comp???__");
 }
 
 TEST(JsonCheckTest, checkHelpSuccess) {

--- a/tests/main_frame/main.cpp
+++ b/tests/main_frame/main.cpp
@@ -173,6 +173,9 @@ TEST(MainFrameTest, LoadSaveConfigAscii) {
 TEST(MainFrameTest, LoadSaveConfigUTF) {
     nlohmann::json test_json = GetTestJson();
     test_json["gui"][0] = test_json["gui"][1];
+    std::string cmd = test_json["gui"][0]["command"].get<std::string>();
+    cmd.replace(12, 4, "ファイル");
+    test_json["gui"][0]["command"] = cmd;
     test_json["gui"][0]["components"][1]["id"] = "ファイル";
     TestConfig(test_json, config_utf);
 }

--- a/tests/main_frame/main.cpp
+++ b/tests/main_frame/main.cpp
@@ -72,8 +72,6 @@ TEST(MainFrameTest, InvalidHelp) {
     test_json["help"][0]["url"] = 1;
     MainFrame* main_frame = new MainFrame(test_json, dummy_config);
     EXPECT_FALSE(main_frame->GetDefinition().contains("help"));
-    EXPECT_EQ(test_json["gui"][0]["components"],
-        main_frame->GetDefinition()["gui"][0]["components"]);
 }
 
 TEST(MainFrameTest, GetCommand1) {
@@ -108,10 +106,7 @@ TEST(MainFrameTest, RunCommandSuccess) {
     nlohmann::json test_json = GetTestJson();
     MainFrame* main_frame = new MainFrame(test_json, dummy_config);
 
-    // The json file should not be fixed by app.
     ASSERT_EQ(test_json["help"], main_frame->GetDefinition()["help"]);
-    ASSERT_EQ(test_json["gui"][0]["components"],
-        main_frame->GetDefinition()["gui"][0]["components"]);
 
     std::string last_line = main_frame->RunCommand();
     EXPECT_STRNE("", last_line.c_str());


### PR DESCRIPTION
- Raise errors when the command requires more components or there are unused components.
- Commands will be shown in the log when loading definitions.
- Fixed a bug that "%%" won't escsape the "%" symbol.
- Fixed a bug that the window is resizable on macOS and Linux.
- Fixed typos.
- Refined codes.
